### PR TITLE
Bug fix: defaultContainer garbage collection

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -9,7 +9,15 @@ export default (props: ViewerProps) => {
   const [ init, setInit ] = React.useState(false);
 
   React.useEffect(() => {
-    document.body.appendChild(defaultContainer.current);
+    const childContainer = defaultContainer.current;
+    document.body.appendChild(childContainer);
+    return () => {
+      try {
+        document.body.removeChild(childContainer);
+      } catch (ex) {
+        console.error("Failed to clean up default container element."); 
+      }
+    };
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
In the previous implementation, the defaultContainer was being created and appended to the document, but was not being cleaned up on unmounting of the Viewer component. The requested change implements clean-up of the defaultContainer on unload.