### PR TITLE
Clean up default generated DOM nodes on unmount

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -9,7 +9,15 @@ export default (props: ViewerProps) => {
   const [ init, setInit ] = React.useState(false);
 
   React.useEffect(() => {
-    document.body.appendChild(defaultContainer.current);
+    const childContainer = defaultContainer.current;
+    document.body.appendChild(childContainer);
+    return () => {
+      try {
+        document.body.removeChild(childContainer);
+      } catch (ex) {
+        console.error("Failed to clean up default container element."); 
+      }
+    };
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
The previous behaviour created a "defaultContainer" DOM node and appended to the document, but did not clean up the generated node on component unmount. This patch includes a fix that cleans up the generated DOM nodes on unmount.