### PR TITLE
fix: side-effect handling

### DIFF
--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -9,7 +9,8 @@ export default (props: ViewerProps) => {
   const [ init, setInit ] = React.useState(false);
 
   React.useEffect(() => {
-    document.body.appendChild(defaultContainer.current);
+    document.body.appendChild(defaultContainer.current); // side-effect needs to be handled.
+    return ()=>{document.body.removeChild(defaultContainer.current);} // side-effect handling
   }, []);
 
   React.useEffect(() => {


### PR DESCRIPTION
there is a div is added to body before "Viewer" mounted. 
It needs to be removed when "Viewer" unmounted or it will always exist in the body element.