### PR TITLE
fix(maskclick): Resolve right click trigger maskclick event

### DIFF
--- a/src/ViewerCanvas.tsx
+++ b/src/ViewerCanvas.tsx
@@ -81,7 +81,6 @@ export default function ViewerCanvas(props: ViewerCanvasProps) {
   }
 
   function handleCanvasMouseDown(e) {
-    props.onCanvasMouseDown(e);
     handleMouseDown(e);
   }
 
@@ -92,6 +91,7 @@ export default function ViewerCanvas(props: ViewerCanvasProps) {
     if (!props.visible || !props.drag) {
       return;
     }
+    props.onCanvasMouseDown(e);
     e.preventDefault();
     e.stopPropagation();
     isMouseDown.current = true;

--- a/src/ViewerCanvas.tsx
+++ b/src/ViewerCanvas.tsx
@@ -128,7 +128,7 @@ export default function ViewerCanvas(props: ViewerCanvasProps) {
       funcName = 'removeEventListener';
     }
 
-    document[funcName]('click', handleMouseUp, false);
+    document[funcName]('mouseup', handleMouseUp, false); // Changed from 'click' to 'mouseup'
     document[funcName]('mousemove', handleMouseMove, false);
   }
 


### PR DESCRIPTION
fix: Mouse right click triggered `onMaskClick` ,which cause the viewer invisible;
 
```
            <Viewer
                visible={visible}
                onClose={() => {
                  setImgViewerVisible(false)
                }}
                onMaskClick={(e) => {
                 e.button ===0 && setImgViewerVisible(false)
                }}
                images={src}
            />
```

**`e.button ===0 && setImgViewerVisible(false)`**