### PR TITLE
Add CI for supported Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 22
+          - 24
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Check package contents
+        run: npm pack --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
 
+      - name: Verify public npm registry
+        run: |
+          test "$(npm config get registry)" = "https://registry.npmjs.org/"
+          ! grep -R "bnpm.byted.org" --include="package-lock.json" .
+
       - name: Install dependencies
         run: npm ci --ignore-scripts
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -11486,7 +11486,7 @@
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
-      "resolved": "http://bnpm.byted.org/mini-css-extract-plugin/download/mini-css-extract-plugin-0.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
       "integrity": "sha1-R/LPB6oWWrNXM7H8l9TEbAVkM54=",
       "dev": true,
       "requires": {

--- a/ssr-test/.npmrc
+++ b/ssr-test/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/ssr-test/package-lock.json
+++ b/ssr-test/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/cli": {
       "version": "7.8.4",
-      "resolved": "http://bnpm.byted.org/@babel/cli/download/@babel/cli-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.8.4.tgz",
       "integrity": "sha1-UF+wU3IamHd7KxdTI+pPCQt9PBw=",
       "requires": {
         "chokidar": "^2.1.8",
@@ -22,7 +22,7 @@
     },
     "@babel/code-frame": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/code-frame/download/@babel/code-frame-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha1-M+JZA9dIEYFTThLsCiXxa2/PQZ4=",
       "dev": true,
       "requires": {
@@ -31,7 +31,7 @@
     },
     "@babel/core": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/core/download/@babel/core-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
       "integrity": "sha1-J9ffklikXC5oa28YtsZZ5WOqRjY=",
       "dev": true,
       "requires": {
@@ -54,7 +54,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://bnpm.byted.org/debug/download/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -63,7 +63,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://bnpm.byted.org/ms/download/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -71,7 +71,7 @@
     },
     "@babel/generator": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/generator/download/@babel/generator-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
       "integrity": "sha1-V635bTcMmmPCQc1xn5ERRoV4U3o=",
       "dev": true,
       "requires": {
@@ -83,7 +83,7 @@
     },
     "@babel/helper-builder-react-jsx": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-builder-react-jsx/download/@babel/helper-builder-react-jsx-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.8.3.tgz",
       "integrity": "sha1-3umNfXnMHwA9gLdv4Bx/iUVmX/Y=",
       "dev": true,
       "requires": {
@@ -93,7 +93,7 @@
     },
     "@babel/helper-create-class-features-plugin": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/helper-create-class-features-plugin/download/@babel/helper-create-class-features-plugin-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
       "integrity": "sha1-JDpbRuL48PZ03BOHYx62souFHeA=",
       "dev": true,
       "requires": {
@@ -107,7 +107,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-function-name/download/@babel/helper-function-name-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
       "integrity": "sha1-7utmWgGx8RBo6fuGrVahyxqCTMo=",
       "dev": true,
       "requires": {
@@ -118,7 +118,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-get-function-arity/download/@babel/helper-get-function-arity-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
       "integrity": "sha1-uJS5R70AQ4HOY+odufCFR+kgq9U=",
       "dev": true,
       "requires": {
@@ -127,7 +127,7 @@
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-member-expression-to-functions/download/@babel/helper-member-expression-to-functions-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
       "integrity": "sha1-ZZtxBJjqbB2ZB+DHPyBu7n2twkw=",
       "dev": true,
       "requires": {
@@ -136,7 +136,7 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-optimise-call-expression/download/@babel/helper-optimise-call-expression-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
       "integrity": "sha1-ftBxgT0Jx1KY708giVYAa2ER7Lk=",
       "dev": true,
       "requires": {
@@ -145,13 +145,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-plugin-utils/download/@babel/helper-plugin-utils-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
       "integrity": "sha1-nqKTvhm6vA9S/4yoizTDYRsghnA=",
       "dev": true
     },
     "@babel/helper-replace-supers": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/helper-replace-supers/download/@babel/helper-replace-supers-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
       "integrity": "sha1-Wtp0T9WtcyA78dZ0WaJ9y6Z+/8g=",
       "dev": true,
       "requires": {
@@ -163,7 +163,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/helper-split-export-declaration/download/@babel/helper-split-export-declaration-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
       "integrity": "sha1-ManzAHD5E2inGCzwX4MXgQZfx6k=",
       "dev": true,
       "requires": {
@@ -172,7 +172,7 @@
     },
     "@babel/helpers": {
       "version": "7.8.4",
-      "resolved": "http://bnpm.byted.org/@babel/helpers/download/@babel/helpers-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
       "integrity": "sha1-dU6z7nJ8Fl4KJA1sIH3nxFXzb3M=",
       "dev": true,
       "requires": {
@@ -183,7 +183,7 @@
     },
     "@babel/highlight": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/highlight/download/@babel/highlight-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
       "integrity": "sha1-KPFz0EIj6qpZvB1Dmjg25tEmV5c=",
       "dev": true,
       "requires": {
@@ -194,7 +194,7 @@
     },
     "@babel/node": {
       "version": "7.8.4",
-      "resolved": "http://bnpm.byted.org/@babel/node/download/@babel/node-7.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/node/-/node-7.8.4.tgz",
       "integrity": "sha1-WbLtflqd8iJFkvgyktd9YW+/Grg=",
       "requires": {
         "@babel/register": "^7.8.3",
@@ -209,13 +209,13 @@
     },
     "@babel/parser": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/parser/download/@babel/parser-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
       "integrity": "sha1-ulyZEM3bd2haAI48WHr40ntnliw=",
       "dev": true
     },
     "@babel/plugin-proposal-decorators": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-proposal-decorators/download/@babel/plugin-proposal-decorators-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
       "integrity": "sha1-IVaGCrZcWr8GjD9nBCGEBBBmVD4=",
       "dev": true,
       "requires": {
@@ -226,7 +226,7 @@
     },
     "@babel/plugin-syntax-decorators": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-syntax-decorators/download/@babel/plugin-syntax-decorators-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
       "integrity": "sha1-jSwVqfGvYksAJflhaCqdU9MAG9o=",
       "dev": true,
       "requires": {
@@ -235,7 +235,7 @@
     },
     "@babel/plugin-syntax-jsx": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-syntax-jsx/download/@babel/plugin-syntax-jsx-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
       "integrity": "sha1-UhsGyDxASA8eWLT9M7kuzrHW6pQ=",
       "dev": true,
       "requires": {
@@ -244,7 +244,7 @@
     },
     "@babel/plugin-transform-react-display-name": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-transform-react-display-name/download/@babel/plugin-transform-react-display-name-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
       "integrity": "sha1-cN7Zh8kWCfeDU9120vsqC7mR6OU=",
       "dev": true,
       "requires": {
@@ -253,7 +253,7 @@
     },
     "@babel/plugin-transform-react-jsx": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-transform-react-jsx/download/@babel/plugin-transform-react-jsx-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.8.3.tgz",
       "integrity": "sha1-QiA0nAOQ/e+lBTZfaMEDViqy/Eo=",
       "dev": true,
       "requires": {
@@ -264,7 +264,7 @@
     },
     "@babel/plugin-transform-react-jsx-self": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-transform-react-jsx-self/download/@babel/plugin-transform-react-jsx-self-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.8.3.tgz",
       "integrity": "sha1-xPF4sqpYjs+o0HfqgNQZTud+1wI=",
       "dev": true,
       "requires": {
@@ -274,7 +274,7 @@
     },
     "@babel/plugin-transform-react-jsx-source": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/plugin-transform-react-jsx-source/download/@babel/plugin-transform-react-jsx-source-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.8.3.tgz",
       "integrity": "sha1-lR51qK9H+fEg23Mb4JXSssNJIOA=",
       "dev": true,
       "requires": {
@@ -284,7 +284,7 @@
     },
     "@babel/preset-react": {
       "version": "7.8.3",
-      "resolved": "http://bnpm.byted.org/@babel/preset-react/download/@babel/preset-react-7.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.8.3.tgz",
       "integrity": "sha1-I9xj8bWwdRKD4EJS54zx1liSc9I=",
       "dev": true,
       "requires": {
@@ -297,7 +297,7 @@
     },
     "@babel/register": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/register/download/@babel/register-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.8.6.tgz",
       "integrity": "sha1-oQZqphaKc6cMNe8ozFhlzMCH6mk=",
       "requires": {
         "find-cache-dir": "^2.0.0",
@@ -309,7 +309,7 @@
     },
     "@babel/template": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/template/download/@babel/template-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
       "integrity": "sha1-hrIq8V+CjfsIZHT5ZNzD45xDzis=",
       "dev": true,
       "requires": {
@@ -320,7 +320,7 @@
     },
     "@babel/traverse": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/traverse/download/@babel/traverse-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
       "integrity": "sha1-rP4MZOHNmRs+MuroE6brVklUtf8=",
       "dev": true,
       "requires": {
@@ -337,7 +337,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://bnpm.byted.org/debug/download/debug-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -346,7 +346,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://bnpm.byted.org/ms/download/ms-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -354,7 +354,7 @@
     },
     "@babel/types": {
       "version": "7.8.6",
-      "resolved": "http://bnpm.byted.org/@babel/types/download/@babel/types-7.8.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
       "integrity": "sha1-Yp7MM8JVf83nEm5YBTEnr9s+bQE=",
       "dev": true,
       "requires": {
@@ -365,13 +365,13 @@
     },
     "@types/prop-types": {
       "version": "15.7.3",
-      "resolved": "http://bnpm.byted.org/@types/prop-types/download/@types/prop-types-15.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha1-KrDV2i5YFflLC51LldHl8kOrLKc=",
       "dev": true
     },
     "@types/react": {
       "version": "16.9.23",
-      "resolved": "http://bnpm.byted.org/@types/react/download/@types/react-16.9.23.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
       "integrity": "sha1-GmbG1Gi6EaiUOtlYqMs+c3VoJxw=",
       "dev": true,
       "requires": {
@@ -381,7 +381,7 @@
     },
     "@types/react-dom": {
       "version": "16.9.5",
-      "resolved": "http://bnpm.byted.org/@types/react-dom/download/@types/react-dom-16.9.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.5.tgz",
       "integrity": "sha1-XeYQsEo10H/9j0TtrZOnEDLZqqc=",
       "dev": true,
       "requires": {
@@ -390,7 +390,7 @@
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/ast/download/@webassemblyjs/ast-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
       "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
       "dev": true,
       "requires": {
@@ -401,25 +401,25 @@
     },
     "@webassemblyjs/floating-point-hex-parser": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/floating-point-hex-parser/download/@webassemblyjs/floating-point-hex-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
       "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-api-error/download/@webassemblyjs/helper-api-error-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
       "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-buffer/download/@webassemblyjs/helper-buffer-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
       "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-code-frame/download/@webassemblyjs/helper-code-frame-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
       "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
       "dev": true,
       "requires": {
@@ -428,13 +428,13 @@
     },
     "@webassemblyjs/helper-fsm": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-fsm/download/@webassemblyjs/helper-fsm-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
       "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-module-context/download/@webassemblyjs/helper-module-context-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
       "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
       "dev": true,
       "requires": {
@@ -444,13 +444,13 @@
     },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-wasm-bytecode/download/@webassemblyjs/helper-wasm-bytecode-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
       "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/helper-wasm-section/download/@webassemblyjs/helper-wasm-section-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
       "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
       "dev": true,
       "requires": {
@@ -462,7 +462,7 @@
     },
     "@webassemblyjs/ieee754": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/ieee754/download/@webassemblyjs/ieee754-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
       "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "dev": true,
       "requires": {
@@ -471,7 +471,7 @@
     },
     "@webassemblyjs/leb128": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/leb128/download/@webassemblyjs/leb128-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
       "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
       "dev": true,
       "requires": {
@@ -480,13 +480,13 @@
     },
     "@webassemblyjs/utf8": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/utf8/download/@webassemblyjs/utf8-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
       "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wasm-edit/download/@webassemblyjs/wasm-edit-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
       "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
       "dev": true,
       "requires": {
@@ -502,7 +502,7 @@
     },
     "@webassemblyjs/wasm-gen": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wasm-gen/download/@webassemblyjs/wasm-gen-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
       "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
       "dev": true,
       "requires": {
@@ -515,7 +515,7 @@
     },
     "@webassemblyjs/wasm-opt": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wasm-opt/download/@webassemblyjs/wasm-opt-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
       "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
       "dev": true,
       "requires": {
@@ -527,7 +527,7 @@
     },
     "@webassemblyjs/wasm-parser": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wasm-parser/download/@webassemblyjs/wasm-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
       "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
       "dev": true,
       "requires": {
@@ -541,7 +541,7 @@
     },
     "@webassemblyjs/wast-parser": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wast-parser/download/@webassemblyjs/wast-parser-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
       "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
       "dev": true,
       "requires": {
@@ -555,7 +555,7 @@
     },
     "@webassemblyjs/wast-printer": {
       "version": "1.8.5",
-      "resolved": "http://bnpm.byted.org/@webassemblyjs/wast-printer/download/@webassemblyjs/wast-printer-1.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
       "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
       "dev": true,
       "requires": {
@@ -566,13 +566,13 @@
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/@xtuc/ieee754/download/@xtuc/ieee754-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
       "dev": true
     },
     "@xtuc/long": {
       "version": "4.2.2",
-      "resolved": "http://bnpm.byted.org/@xtuc/long/download/@xtuc/long-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
       "dev": true
     },
@@ -605,13 +605,13 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/ajv-errors/download/ajv-errors-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
       "dev": true
     },
     "ajv-keywords": {
       "version": "3.4.1",
-      "resolved": "http://bnpm.byted.org/ajv-keywords/download/ajv-keywords-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
       "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
       "dev": true
     },
@@ -623,7 +623,7 @@
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "http://bnpm.byted.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
@@ -632,7 +632,7 @@
     },
     "anymatch": {
       "version": "2.0.0",
-      "resolved": "http://bnpm.byted.org/anymatch/download/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "requires": {
         "micromatch": "^3.1.4",
@@ -641,7 +641,7 @@
       "dependencies": {
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "http://bnpm.byted.org/normalize-path/download/normalize-path-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
             "remove-trailing-separator": "^1.0.1"
@@ -651,23 +651,23 @@
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/aproba/download/aproba-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://bnpm.byted.org/arr-diff/download/arr-diff-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/arr-flatten/download/arr-flatten-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://bnpm.byted.org/arr-union/download/arr-union-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
     "array-flatten": {
@@ -677,12 +677,12 @@
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://bnpm.byted.org/array-unique/download/array-unique-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "asn1.js": {
       "version": "4.10.1",
-      "resolved": "http://bnpm.byted.org/asn1.js/download/asn1.js-4.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
       "dev": true,
       "requires": {
@@ -693,7 +693,7 @@
     },
     "assert": {
       "version": "1.5.0",
-      "resolved": "http://bnpm.byted.org/assert/download/assert-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
       "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
       "dev": true,
       "requires": {
@@ -703,13 +703,13 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/inherits/download/inherits-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
           "dev": true
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://bnpm.byted.org/util/download/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -720,22 +720,22 @@
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/assign-symbols/download/assign-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "async-each": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/async-each/download/async-each-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8="
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://bnpm.byted.org/atob/download/atob-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
     },
     "babel-loader": {
       "version": "8.0.6",
-      "resolved": "http://bnpm.byted.org/babel-loader/download/babel-loader-8.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
       "integrity": "sha1-4zvbbzYrA/S7FBoMIauHxQG3Dfs=",
       "dev": true,
       "requires": {
@@ -747,12 +747,12 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/balanced-match/download/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://bnpm.byted.org/base/download/base-0.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "requires": {
         "cache-base": "^1.0.1",
@@ -766,7 +766,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -774,7 +774,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -782,7 +782,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -790,7 +790,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://bnpm.byted.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -802,24 +802,24 @@
     },
     "base64-js": {
       "version": "1.3.1",
-      "resolved": "http://bnpm.byted.org/base64-js/download/base64-js-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
       "dev": true
     },
     "big.js": {
       "version": "5.2.2",
-      "resolved": "http://bnpm.byted.org/big.js/download/big.js-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
-      "resolved": "http://bnpm.byted.org/binary-extensions/download/binary-extensions-1.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U="
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "http://bnpm.byted.org/bindings/download/bindings-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "optional": true,
       "requires": {
@@ -828,13 +828,13 @@
     },
     "bluebird": {
       "version": "3.7.2",
-      "resolved": "http://bnpm.byted.org/bluebird/download/bluebird-3.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
       "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
-      "resolved": "http://bnpm.byted.org/bn.js/download/bn.js-4.11.8.tgz",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
       "dev": true
     },
@@ -859,7 +859,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://bnpm.byted.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
@@ -868,7 +868,7 @@
     },
     "braces": {
       "version": "2.3.2",
-      "resolved": "http://bnpm.byted.org/braces/download/braces-2.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
       "requires": {
         "arr-flatten": "^1.1.0",
@@ -885,7 +885,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -895,13 +895,13 @@
     },
     "brorand": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/brorand/download/brorand-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/browserify-aes/download/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
       "dev": true,
       "requires": {
@@ -915,7 +915,7 @@
     },
     "browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/browserify-cipher/download/browserify-cipher-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
       "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
       "dev": true,
       "requires": {
@@ -926,7 +926,7 @@
     },
     "browserify-des": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/browserify-des/download/browserify-des-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
       "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
       "dev": true,
       "requires": {
@@ -938,7 +938,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://bnpm.byted.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -948,7 +948,7 @@
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "resolved": "http://bnpm.byted.org/browserify-sign/download/browserify-sign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
@@ -963,7 +963,7 @@
     },
     "browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "http://bnpm.byted.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "dev": true,
       "requires": {
@@ -972,7 +972,7 @@
     },
     "buffer": {
       "version": "4.9.2",
-      "resolved": "http://bnpm.byted.org/buffer/download/buffer-4.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
       "dev": true,
       "requires": {
@@ -983,18 +983,18 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/buffer-from/download/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/buffer-xor/download/buffer-xor-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
@@ -1005,7 +1005,7 @@
     },
     "cacache": {
       "version": "12.0.3",
-      "resolved": "http://bnpm.byted.org/cacache/download/cacache-12.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
       "integrity": "sha1-vpmruk4b9d9GHNWiwQcfxDJXM5A=",
       "dev": true,
       "requires": {
@@ -1028,7 +1028,7 @@
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/cache-base/download/cache-base-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "requires": {
         "collection-visit": "^1.0.0",
@@ -1075,7 +1075,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "http://bnpm.byted.org/chalk/download/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
@@ -1086,7 +1086,7 @@
     },
     "chokidar": {
       "version": "2.1.8",
-      "resolved": "http://bnpm.byted.org/chokidar/download/chokidar-2.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
       "requires": {
         "anymatch": "^2.0.0",
@@ -1105,13 +1105,13 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "http://bnpm.byted.org/chownr/download/chownr-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
       "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/chrome-trace-event/download/chrome-trace-event-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
       "dev": true,
       "requires": {
@@ -1120,7 +1120,7 @@
     },
     "cipher-base": {
       "version": "1.0.4",
-      "resolved": "http://bnpm.byted.org/cipher-base/download/cipher-base-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "dev": true,
       "requires": {
@@ -1130,7 +1130,7 @@
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://bnpm.byted.org/class-utils/download/class-utils-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -1141,7 +1141,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1162,7 +1162,7 @@
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/collection-visit/download/collection-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "requires": {
         "map-visit": "^1.0.0",
@@ -1171,7 +1171,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "http://bnpm.byted.org/color-convert/download/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -1180,33 +1180,33 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "http://bnpm.byted.org/color-name/download/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
       "version": "4.1.1",
-      "resolved": "http://bnpm.byted.org/commander/download/commander-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha1-n9YCvZNilOnp70aj9NaWQESxgGg="
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/commondir/download/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "http://bnpm.byted.org/component-emitter/download/component-emitter-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://bnpm.byted.org/concat-map/download/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://bnpm.byted.org/concat-stream/download/concat-stream-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -1218,13 +1218,13 @@
     },
     "console-browserify": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/console-browserify/download/console-browserify-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
       "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/constants-browserify/download/constants-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
@@ -1250,7 +1250,7 @@
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "http://bnpm.byted.org/convert-source-map/download/convert-source-map-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -1268,7 +1268,7 @@
     },
     "copy-concurrently": {
       "version": "1.0.5",
-      "resolved": "http://bnpm.byted.org/copy-concurrently/download/copy-concurrently-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
       "dev": true,
       "requires": {
@@ -1282,22 +1282,22 @@
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://bnpm.byted.org/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
       "version": "3.6.4",
-      "resolved": "http://bnpm.byted.org/core-js/download/core-js-3.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
       "integrity": "sha1-RAqDU2tFgRS5yyrBWAujd9xHBkc="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/core-util-is/download/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.3",
-      "resolved": "http://bnpm.byted.org/create-ecdh/download/create-ecdh-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
       "dev": true,
       "requires": {
@@ -1307,7 +1307,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/create-hash/download/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
       "dev": true,
       "requires": {
@@ -1320,7 +1320,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://bnpm.byted.org/create-hmac/download/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
       "dev": true,
       "requires": {
@@ -1347,7 +1347,7 @@
     },
     "crypto-browserify": {
       "version": "3.12.0",
-      "resolved": "http://bnpm.byted.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "dev": true,
       "requires": {
@@ -1366,19 +1366,19 @@
     },
     "csstype": {
       "version": "2.6.9",
-      "resolved": "http://bnpm.byted.org/csstype/download/csstype-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
       "integrity": "sha1-BRQdDNVXpWuIkTlMGRHEDIqY0Jg=",
       "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/cyclist/download/cyclist-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "resolved": "http://bnpm.byted.org/debug/download/debug-2.6.9.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
@@ -1397,7 +1397,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "http://bnpm.byted.org/define-properties/download/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
@@ -1405,7 +1405,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://bnpm.byted.org/define-property/download/define-property-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "requires": {
         "is-descriptor": "^1.0.2",
@@ -1414,7 +1414,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1422,7 +1422,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1430,7 +1430,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://bnpm.byted.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1447,7 +1447,7 @@
     },
     "des.js": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/des.js/download/des.js-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
       "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
       "dev": true,
       "requires": {
@@ -1468,7 +1468,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://bnpm.byted.org/diffie-hellman/download/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
       "dev": true,
       "requires": {
@@ -1479,7 +1479,7 @@
     },
     "domain-browser": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/domain-browser/download/domain-browser-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
     },
@@ -1495,7 +1495,7 @@
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "http://bnpm.byted.org/duplexify/download/duplexify-3.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
@@ -1541,7 +1541,7 @@
     },
     "emojis-list": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/emojis-list/download/emojis-list-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
       "dev": true
     },
@@ -1552,7 +1552,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "http://bnpm.byted.org/end-of-stream/download/end-of-stream-1.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
@@ -1561,7 +1561,7 @@
     },
     "enhanced-resolve": {
       "version": "4.1.1",
-      "resolved": "http://bnpm.byted.org/enhanced-resolve/download/enhanced-resolve-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
       "integrity": "sha1-KTfiuAZs0P584JkKmPDXGjUYn2Y=",
       "dev": true,
       "requires": {
@@ -1572,7 +1572,7 @@
       "dependencies": {
         "memory-fs": {
           "version": "0.5.0",
-          "resolved": "http://bnpm.byted.org/memory-fs/download/memory-fs-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
           "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
           "dev": true,
           "requires": {
@@ -1584,7 +1584,7 @@
     },
     "errno": {
       "version": "0.1.7",
-      "resolved": "http://bnpm.byted.org/errno/download/errno-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
       "dev": true,
       "requires": {
@@ -1593,7 +1593,7 @@
     },
     "es-abstract": {
       "version": "1.17.4",
-      "resolved": "http://bnpm.byted.org/es-abstract/download/es-abstract-1.17.4.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
       "integrity": "sha1-467fGXBrIOfCWUw1/A1XYFp54YQ=",
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -1629,7 +1629,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "http://bnpm.byted.org/es-to-primitive/download/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "requires": {
         "is-callable": "^1.1.4",
@@ -1644,13 +1644,13 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://bnpm.byted.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint-scope": {
       "version": "4.0.3",
-      "resolved": "http://bnpm.byted.org/eslint-scope/download/eslint-scope-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
       "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
       "dev": true,
       "requires": {
@@ -1660,7 +1660,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "http://bnpm.byted.org/esrecurse/download/esrecurse-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -1669,13 +1669,13 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://bnpm.byted.org/estraverse/download/estraverse-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "http://bnpm.byted.org/esutils/download/esutils-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
@@ -1686,13 +1686,13 @@
     },
     "events": {
       "version": "3.1.0",
-      "resolved": "http://bnpm.byted.org/events/download/events-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
       "integrity": "sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=",
       "dev": true
     },
     "evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "dev": true,
       "requires": {
@@ -1702,7 +1702,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://bnpm.byted.org/expand-brackets/download/expand-brackets-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "requires": {
         "debug": "^2.3.3",
@@ -1716,7 +1716,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -1724,7 +1724,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1788,7 +1788,7 @@
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "requires": {
         "assign-symbols": "^1.0.0",
@@ -1797,7 +1797,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://bnpm.byted.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -1807,7 +1807,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://bnpm.byted.org/extglob/download/extglob-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "requires": {
         "array-unique": "^0.3.2",
@@ -1822,7 +1822,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -1830,7 +1830,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1838,7 +1838,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1846,7 +1846,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -1854,7 +1854,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://bnpm.byted.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -1866,31 +1866,31 @@
     },
     "fast-deep-equal": {
       "version": "3.1.1",
-      "resolved": "http://bnpm.byted.org/fast-deep-equal/download/fast-deep-equal-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://bnpm.byted.org/fast-json-stable-stringify/download/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.1",
-      "resolved": "http://bnpm.byted.org/figgy-pudding/download/figgy-pudding-3.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
       "integrity": "sha1-hiRwESkBxyeg5JWoB0S9W6odZ5A=",
       "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/file-uri-to-path/download/file-uri-to-path-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
-      "resolved": "http://bnpm.byted.org/fill-range/download/fill-range-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -1901,7 +1901,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -1925,7 +1925,7 @@
     },
     "find-cache-dir": {
       "version": "2.1.0",
-      "resolved": "http://bnpm.byted.org/find-cache-dir/download/find-cache-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
       "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
       "requires": {
         "commondir": "^1.0.1",
@@ -1935,7 +1935,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/find-up/download/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "requires": {
         "locate-path": "^3.0.0"
@@ -1955,7 +1955,7 @@
     },
     "flush-write-stream": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/flush-write-stream/download/flush-write-stream-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
       "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
       "dev": true,
       "requires": {
@@ -1965,7 +1965,7 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/for-in/download/for-in-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
     "forwarded": {
@@ -1975,7 +1975,7 @@
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://bnpm.byted.org/fragment-cache/download/fragment-cache-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "requires": {
         "map-cache": "^0.2.2"
@@ -1988,7 +1988,7 @@
     },
     "from2": {
       "version": "2.3.0",
-      "resolved": "http://bnpm.byted.org/from2/download/from2-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
@@ -1998,12 +1998,12 @@
     },
     "fs-readdir-recursive": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/fs-readdir-recursive/download/fs-readdir-recursive-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc="
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
-      "resolved": "http://bnpm.byted.org/fs-write-stream-atomic/download/fs-write-stream-atomic-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
@@ -2015,12 +2015,12 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.11",
-      "resolved": "http://bnpm.byted.org/fsevents/download/fsevents-1.2.11.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
       "integrity": "sha1-Z79X9HWPAu3oj7KhcS/vTRU1i+M=",
       "optional": true,
       "requires": {
@@ -2490,12 +2490,12 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/function-bind/download/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gensync": {
       "version": "1.0.0-beta.1",
-      "resolved": "http://bnpm.byted.org/gensync/download/gensync-1.0.0-beta.1.tgz",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
       "dev": true
     },
@@ -2536,12 +2536,12 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://bnpm.byted.org/get-value/download/get-value-2.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "http://bnpm.byted.org/glob/download/glob-7.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2554,7 +2554,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "http://bnpm.byted.org/glob-parent/download/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "requires": {
         "is-glob": "^3.1.0",
@@ -2563,7 +2563,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://bnpm.byted.org/is-glob/download/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
             "is-extglob": "^2.1.0"
@@ -2608,7 +2608,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "http://bnpm.byted.org/globals/download/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
@@ -2619,12 +2619,12 @@
     },
     "graceful-fs": {
       "version": "4.2.3",
-      "resolved": "http://bnpm.byted.org/graceful-fs/download/graceful-fs-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM="
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/has/download/has-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
@@ -2632,18 +2632,18 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/has-flag/download/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/has-symbols/download/has-symbols-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/has-value/download/has-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "requires": {
         "get-value": "^2.0.6",
@@ -2653,7 +2653,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/has-values/download/has-values-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "requires": {
         "is-number": "^3.0.0",
@@ -2662,7 +2662,7 @@
       "dependencies": {
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2672,7 +2672,7 @@
     },
     "hash-base": {
       "version": "3.0.4",
-      "resolved": "http://bnpm.byted.org/hash-base/download/hash-base-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
@@ -2682,7 +2682,7 @@
     },
     "hash.js": {
       "version": "1.1.7",
-      "resolved": "http://bnpm.byted.org/hash.js/download/hash.js-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
       "dev": true,
       "requires": {
@@ -2707,7 +2707,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
@@ -2718,7 +2718,7 @@
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/homedir-polyfill/download/homedir-polyfill-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "requires": {
         "parse-passwd": "^1.0.0"
@@ -2738,7 +2738,7 @@
     },
     "https-browserify": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/https-browserify/download/https-browserify-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
@@ -2752,13 +2752,13 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "http://bnpm.byted.org/ieee754/download/ieee754-1.1.13.tgz",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "iferr": {
       "version": "0.1.5",
-      "resolved": "http://bnpm.byted.org/iferr/download/iferr-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
@@ -2774,19 +2774,19 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://bnpm.byted.org/imurmurhash/download/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
-      "resolved": "http://bnpm.byted.org/infer-owner/download/infer-owner-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://bnpm.byted.org/inflight/download/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -2795,7 +2795,7 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://bnpm.byted.org/inherits/download/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
@@ -2817,7 +2817,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://bnpm.byted.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2825,7 +2825,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2835,7 +2835,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
         "binary-extensions": "^1.0.0"
@@ -2843,17 +2843,17 @@
     },
     "is-buffer": {
       "version": "1.1.6",
-      "resolved": "http://bnpm.byted.org/is-buffer/download/is-buffer-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-callable": {
       "version": "1.1.5",
-      "resolved": "http://bnpm.byted.org/is-callable/download/is-callable-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
       "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs="
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://bnpm.byted.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2861,7 +2861,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2871,12 +2871,12 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/is-date-object/download/is-date-object-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://bnpm.byted.org/is-descriptor/download/is-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
@@ -2886,19 +2886,19 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
         }
       }
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://bnpm.byted.org/is-extendable/download/is-extendable-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/is-extglob/download/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -2909,7 +2909,7 @@
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "http://bnpm.byted.org/is-glob/download/is-glob-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "requires": {
         "is-extglob": "^2.1.1"
@@ -2917,7 +2917,7 @@
     },
     "is-number": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/is-number/download/is-number-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -2925,7 +2925,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -2935,7 +2935,7 @@
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://bnpm.byted.org/is-plain-object/download/is-plain-object-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "^3.0.1"
@@ -2943,7 +2943,7 @@
     },
     "is-regex": {
       "version": "1.0.5",
-      "resolved": "http://bnpm.byted.org/is-regex/download/is-regex-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
       "requires": {
         "has": "^1.0.3"
@@ -2951,7 +2951,7 @@
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/is-symbol/download/is-symbol-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "requires": {
         "has-symbols": "^1.0.1"
@@ -2959,18 +2959,18 @@
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/is-windows/download/is-windows-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
     },
     "is-wsl": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/is-wsl/download/is-wsl-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/isarray/download/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
@@ -2981,36 +2981,36 @@
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://bnpm.byted.org/isobject/download/isobject-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://bnpm.byted.org/js-tokens/download/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://bnpm.byted.org/jsesc/download/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/json-parse-better-errors/download/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://bnpm.byted.org/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json5": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/json5/download/json5-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
       "integrity": "sha1-gbbLBOm6SW8ccAXQe0NoomOPkLY=",
       "dev": true,
       "requires": {
@@ -3019,12 +3019,12 @@
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0="
     },
     "loader-runner": {
       "version": "2.4.0",
-      "resolved": "http://bnpm.byted.org/loader-runner/download/loader-runner-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
       "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
       "dev": true
     },
@@ -3052,7 +3052,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/locate-path/download/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "requires": {
         "p-locate": "^3.0.0",
@@ -3066,7 +3066,7 @@
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "http://bnpm.byted.org/lru-cache/download/lru-cache-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
@@ -3075,7 +3075,7 @@
     },
     "make-dir": {
       "version": "2.1.0",
-      "resolved": "http://bnpm.byted.org/make-dir/download/make-dir-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "requires": {
         "pify": "^4.0.1",
@@ -3084,18 +3084,18 @@
     },
     "mamacro": {
       "version": "0.0.3",
-      "resolved": "http://bnpm.byted.org/mamacro/download/mamacro-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
       "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
       "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://bnpm.byted.org/map-cache/download/map-cache-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/map-visit/download/map-visit-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
@@ -3108,7 +3108,7 @@
     },
     "md5.js": {
       "version": "1.3.5",
-      "resolved": "http://bnpm.byted.org/md5.js/download/md5.js-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
       "dev": true,
       "requires": {
@@ -3124,7 +3124,7 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "resolved": "http://bnpm.byted.org/memory-fs/download/memory-fs-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
@@ -3144,7 +3144,7 @@
     },
     "micromatch": {
       "version": "3.1.10",
-      "resolved": "http://bnpm.byted.org/micromatch/download/micromatch-3.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -3164,7 +3164,7 @@
     },
     "miller-rabin": {
       "version": "4.0.1",
-      "resolved": "http://bnpm.byted.org/miller-rabin/download/miller-rabin-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
       "dev": true,
       "requires": {
@@ -3192,19 +3192,19 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://bnpm.byted.org/minimatch/download/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -3217,7 +3217,7 @@
     },
     "mississippi": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/mississippi/download/mississippi-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
       "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
@@ -3235,7 +3235,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "http://bnpm.byted.org/mixin-deep/download/mixin-deep-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "requires": {
         "for-in": "^1.0.2",
@@ -3244,7 +3244,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://bnpm.byted.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
@@ -3262,7 +3262,7 @@
     },
     "move-concurrently": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/move-concurrently/download/move-concurrently-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
@@ -3276,18 +3276,18 @@
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://bnpm.byted.org/ms/download/ms-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.14.0",
-      "resolved": "http://bnpm.byted.org/nan/download/nan-2.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://bnpm.byted.org/nanomatch/download/nanomatch-1.2.13.tgz",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "requires": {
         "arr-diff": "^4.0.0",
@@ -3310,7 +3310,7 @@
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "http://bnpm.byted.org/neo-async/download/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
@@ -3322,7 +3322,7 @@
     },
     "node-environment-flags": {
       "version": "1.0.6",
-      "resolved": "http://bnpm.byted.org/node-environment-flags/download/node-environment-flags-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
       "integrity": "sha1-owrBNiH299Z0JgpU3t4EjDmCwIg=",
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
@@ -3331,7 +3331,7 @@
     },
     "node-libs-browser": {
       "version": "2.2.1",
-      "resolved": "http://bnpm.byted.org/node-libs-browser/download/node-libs-browser-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
       "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
       "dev": true,
       "requires": {
@@ -3362,7 +3362,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://bnpm.byted.org/punycode/download/punycode-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
@@ -3370,23 +3370,23 @@
     },
     "node-modules-regexp": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/node-modules-regexp/download/node-modules-regexp-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
       "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/normalize-path/download/normalize-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://bnpm.byted.org/object-assign/download/object-assign-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://bnpm.byted.org/object-copy/download/object-copy-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "requires": {
         "copy-descriptor": "^0.1.0",
@@ -3396,7 +3396,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -3404,7 +3404,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -3414,17 +3414,17 @@
     },
     "object-inspect": {
       "version": "1.7.0",
-      "resolved": "http://bnpm.byted.org/object-inspect/download/object-inspect-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
       "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc="
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/object-keys/download/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/object-visit/download/object-visit-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
@@ -3432,7 +3432,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "http://bnpm.byted.org/object.assign/download/object.assign-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "requires": {
         "define-properties": "^1.1.2",
@@ -3443,7 +3443,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
-      "resolved": "http://bnpm.byted.org/object.getownpropertydescriptors/download/object.getownpropertydescriptors-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -3452,7 +3452,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://bnpm.byted.org/object.pick/download/object.pick-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "requires": {
         "isobject": "^3.0.1"
@@ -3468,7 +3468,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://bnpm.byted.org/once/download/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -3476,13 +3476,13 @@
     },
     "os-browserify": {
       "version": "0.3.0",
-      "resolved": "http://bnpm.byted.org/os-browserify/download/os-browserify-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
     "p-limit": {
       "version": "2.2.2",
-      "resolved": "http://bnpm.byted.org/p-limit/download/p-limit-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
       "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
       "requires": {
         "p-try": "^2.0.0"
@@ -3490,7 +3490,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/p-locate/download/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "requires": {
         "p-limit": "^2.0.0"
@@ -3498,18 +3498,18 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "http://bnpm.byted.org/p-try/download/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "http://bnpm.byted.org/pako/download/pako-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true
     },
     "parallel-transform": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/parallel-transform/download/parallel-transform-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
       "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
       "dev": true,
       "requires": {
@@ -3520,7 +3520,7 @@
     },
     "parse-asn1": {
       "version": "5.1.5",
-      "resolved": "http://bnpm.byted.org/parse-asn1/download/parse-asn1-5.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
       "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
       "dev": true,
       "requires": {
@@ -3534,7 +3534,7 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/parse-passwd/download/parse-passwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parseurl": {
@@ -3544,28 +3544,28 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://bnpm.byted.org/pascalcase/download/pascalcase-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-browserify": {
       "version": "0.0.1",
-      "resolved": "http://bnpm.byted.org/path-browserify/download/path-browserify-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/path-dirname/download/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/path-exists/download/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -3586,7 +3586,7 @@
     },
     "pbkdf2": {
       "version": "3.0.17",
-      "resolved": "http://bnpm.byted.org/pbkdf2/download/pbkdf2-3.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
       "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
       "dev": true,
       "requires": {
@@ -3599,12 +3599,12 @@
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "http://bnpm.byted.org/pify/download/pify-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
     },
     "pirates": {
       "version": "4.0.1",
-      "resolved": "http://bnpm.byted.org/pirates/download/pirates-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
       "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
       "requires": {
         "node-modules-regexp": "^1.0.0"
@@ -3612,7 +3612,7 @@
     },
     "pkg-dir": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/pkg-dir/download/pkg-dir-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
       "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "requires": {
         "find-up": "^3.0.0"
@@ -3620,23 +3620,23 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://bnpm.byted.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "http://bnpm.byted.org/process/download/process-0.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://bnpm.byted.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/promise-inflight/download/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
@@ -3651,13 +3651,13 @@
     },
     "prr": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/prr/download/prr-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
-      "resolved": "http://bnpm.byted.org/public-encrypt/download/public-encrypt-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
       "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
       "dev": true,
       "requires": {
@@ -3671,7 +3671,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "http://bnpm.byted.org/pump/download/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
@@ -3681,7 +3681,7 @@
     },
     "pumpify": {
       "version": "1.5.1",
-      "resolved": "http://bnpm.byted.org/pumpify/download/pumpify-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
       "dev": true,
       "requires": {
@@ -3692,7 +3692,7 @@
       "dependencies": {
         "pump": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/pump/download/pump-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
@@ -3704,7 +3704,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/punycode/download/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
@@ -3718,19 +3718,19 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://bnpm.byted.org/querystring/download/querystring-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "resolved": "http://bnpm.byted.org/querystring-es3/download/querystring-es3-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
-      "resolved": "http://bnpm.byted.org/randombytes/download/randombytes-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
       "dev": true,
       "requires": {
@@ -3739,7 +3739,7 @@
     },
     "randomfill": {
       "version": "1.0.4",
-      "resolved": "http://bnpm.byted.org/randomfill/download/randomfill-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
       "dev": true,
       "requires": {
@@ -3765,7 +3765,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://bnpm.byted.org/readable-stream/download/readable-stream-2.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -3779,7 +3779,7 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "http://bnpm.byted.org/readdirp/download/readdirp-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -3789,12 +3789,12 @@
     },
     "regenerator-runtime": {
       "version": "0.13.3",
-      "resolved": "http://bnpm.byted.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
       "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U="
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/regex-not/download/regex-not-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "requires": {
         "extend-shallow": "^3.0.2",
@@ -3803,17 +3803,17 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://bnpm.byted.org/repeat-element/download/repeat-element-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://bnpm.byted.org/repeat-string/download/repeat-string-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "require-directory": {
@@ -3830,7 +3830,7 @@
     },
     "resolve": {
       "version": "1.15.1",
-      "resolved": "http://bnpm.byted.org/resolve/download/resolve-1.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
       "integrity": "sha1-J73N7/6vLWJEuVuw+fS0ZTRR8+g=",
       "requires": {
         "path-parse": "^1.0.6"
@@ -3876,17 +3876,17 @@
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://bnpm.byted.org/resolve-url/download/resolve-url-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://bnpm.byted.org/ret/download/ret-0.1.15.tgz",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "http://bnpm.byted.org/rimraf/download/rimraf-2.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "dev": true,
       "requires": {
@@ -3895,7 +3895,7 @@
     },
     "ripemd160": {
       "version": "2.0.2",
-      "resolved": "http://bnpm.byted.org/ripemd160/download/ripemd160-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
       "dev": true,
       "requires": {
@@ -3905,7 +3905,7 @@
     },
     "run-queue": {
       "version": "1.0.3",
-      "resolved": "http://bnpm.byted.org/run-queue/download/run-queue-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
@@ -3914,12 +3914,12 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://bnpm.byted.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://bnpm.byted.org/safe-regex/download/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -3932,7 +3932,7 @@
     },
     "schema-utils": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/schema-utils/download/schema-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "requires": {
@@ -3943,7 +3943,7 @@
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "http://bnpm.byted.org/semver/download/semver-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
     },
     "send": {
@@ -3980,7 +3980,7 @@
     },
     "serialize-javascript": {
       "version": "2.1.2",
-      "resolved": "http://bnpm.byted.org/serialize-javascript/download/serialize-javascript-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
       "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
       "dev": true
     },
@@ -4003,7 +4003,7 @@
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "http://bnpm.byted.org/set-value/download/set-value-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -4014,7 +4014,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4024,7 +4024,7 @@
     },
     "setimmediate": {
       "version": "1.0.5",
-      "resolved": "http://bnpm.byted.org/setimmediate/download/setimmediate-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
     },
@@ -4035,7 +4035,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://bnpm.byted.org/sha.js/download/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
       "dev": true,
       "requires": {
@@ -4132,12 +4132,12 @@
     },
     "slash": {
       "version": "2.0.0",
-      "resolved": "http://bnpm.byted.org/slash/download/slash-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q="
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://bnpm.byted.org/snapdragon/download/snapdragon-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "requires": {
         "base": "^0.11.1",
@@ -4152,7 +4152,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4160,7 +4160,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://bnpm.byted.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "requires": {
             "is-extendable": "^0.1.0"
@@ -4170,7 +4170,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/snapdragon-node/download/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "requires": {
         "define-property": "^1.0.0",
@@ -4180,7 +4180,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "requires": {
             "is-descriptor": "^1.0.0"
@@ -4188,7 +4188,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4196,7 +4196,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://bnpm.byted.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "requires": {
             "kind-of": "^6.0.0"
@@ -4204,7 +4204,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://bnpm.byted.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
@@ -4216,7 +4216,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://bnpm.byted.org/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "requires": {
         "kind-of": "^3.2.0"
@@ -4224,7 +4224,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4234,18 +4234,18 @@
     },
     "source-list-map": {
       "version": "2.0.1",
-      "resolved": "http://bnpm.byted.org/source-list-map/download/source-list-map-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
       "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "http://bnpm.byted.org/source-map/download/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "http://bnpm.byted.org/source-map-resolve/download/source-map-resolve-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "requires": {
         "atob": "^2.1.2",
@@ -4257,7 +4257,7 @@
     },
     "source-map-support": {
       "version": "0.5.16",
-      "resolved": "http://bnpm.byted.org/source-map-support/download/source-map-support-0.5.16.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
       "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
       "requires": {
         "buffer-from": "^1.0.0",
@@ -4266,19 +4266,19 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://bnpm.byted.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://bnpm.byted.org/source-map-url/download/source-map-url-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://bnpm.byted.org/split-string/download/split-string-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "requires": {
         "extend-shallow": "^3.0.0"
@@ -4295,7 +4295,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://bnpm.byted.org/static-extend/download/static-extend-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "requires": {
         "define-property": "^0.2.5",
@@ -4304,7 +4304,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://bnpm.byted.org/define-property/download/define-property-0.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "requires": {
             "is-descriptor": "^0.1.0"
@@ -4319,7 +4319,7 @@
     },
     "stream-browserify": {
       "version": "2.0.2",
-      "resolved": "http://bnpm.byted.org/stream-browserify/download/stream-browserify-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
       "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
       "dev": true,
       "requires": {
@@ -4329,7 +4329,7 @@
     },
     "stream-each": {
       "version": "1.2.3",
-      "resolved": "http://bnpm.byted.org/stream-each/download/stream-each-1.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
       "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
       "dev": true,
       "requires": {
@@ -4339,7 +4339,7 @@
     },
     "stream-http": {
       "version": "2.8.3",
-      "resolved": "http://bnpm.byted.org/stream-http/download/stream-http-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
       "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
       "dev": true,
       "requires": {
@@ -4352,7 +4352,7 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/stream-shift/download/stream-shift-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
@@ -4369,7 +4369,7 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/string.prototype.trimleft/download/string.prototype.trimleft-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -4378,7 +4378,7 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/string.prototype.trimright/download/string.prototype.trimright-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=",
       "requires": {
         "define-properties": "^1.1.3",
@@ -4387,7 +4387,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/string_decoder/download/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -4404,7 +4404,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "http://bnpm.byted.org/supports-color/download/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
@@ -4413,7 +4413,7 @@
     },
     "tapable": {
       "version": "1.1.3",
-      "resolved": "http://bnpm.byted.org/tapable/download/tapable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
       "dev": true
     },
@@ -4444,7 +4444,7 @@
     },
     "terser-webpack-plugin": {
       "version": "1.4.3",
-      "resolved": "http://bnpm.byted.org/terser-webpack-plugin/download/terser-webpack-plugin-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
       "integrity": "sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=",
       "dev": true,
       "requires": {
@@ -4461,7 +4461,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://bnpm.byted.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -4469,7 +4469,7 @@
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://bnpm.byted.org/through2/download/through2-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
@@ -4479,7 +4479,7 @@
     },
     "timers-browserify": {
       "version": "2.0.11",
-      "resolved": "http://bnpm.byted.org/timers-browserify/download/timers-browserify-2.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
       "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
       "dev": true,
       "requires": {
@@ -4488,19 +4488,19 @@
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://bnpm.byted.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://bnpm.byted.org/to-object-path/download/to-object-path-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "requires": {
         "kind-of": "^3.0.2"
@@ -4508,7 +4508,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://bnpm.byted.org/kind-of/download/kind-of-3.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -4518,7 +4518,7 @@
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://bnpm.byted.org/to-regex/download/to-regex-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "requires": {
         "define-property": "^2.0.2",
@@ -4529,7 +4529,7 @@
     },
     "to-regex-range": {
       "version": "2.1.1",
-      "resolved": "http://bnpm.byted.org/to-regex-range/download/to-regex-range-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "requires": {
         "is-number": "^3.0.0",
@@ -4543,13 +4543,13 @@
     },
     "tslib": {
       "version": "1.11.1",
-      "resolved": "http://bnpm.byted.org/tslib/download/tslib-1.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha1-6xXRKIJ/vuKEFUnhcfRe0zisfjU=",
       "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://bnpm.byted.org/tty-browserify/download/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
@@ -4564,13 +4564,13 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://bnpm.byted.org/typedarray/download/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "http://bnpm.byted.org/union-value/download/union-value-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "requires": {
         "arr-union": "^3.1.0",
@@ -4581,7 +4581,7 @@
     },
     "unique-filename": {
       "version": "1.1.1",
-      "resolved": "http://bnpm.byted.org/unique-filename/download/unique-filename-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
       "dev": true,
       "requires": {
@@ -4590,7 +4590,7 @@
     },
     "unique-slug": {
       "version": "2.0.2",
-      "resolved": "http://bnpm.byted.org/unique-slug/download/unique-slug-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
       "dev": true,
       "requires": {
@@ -4604,7 +4604,7 @@
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://bnpm.byted.org/unset-value/download/unset-value-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "requires": {
         "has-value": "^0.3.1",
@@ -4613,7 +4613,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://bnpm.byted.org/has-value/download/has-value-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "requires": {
             "get-value": "^2.0.3",
@@ -4623,7 +4623,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://bnpm.byted.org/isobject/download/isobject-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "requires": {
                 "isarray": "1.0.0"
@@ -4633,19 +4633,19 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://bnpm.byted.org/has-values/download/has-values-0.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
       }
     },
     "upath": {
       "version": "1.2.0",
-      "resolved": "http://bnpm.byted.org/upath/download/upath-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ="
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "http://bnpm.byted.org/uri-js/download/uri-js-4.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
@@ -4654,12 +4654,12 @@
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://bnpm.byted.org/urix/download/urix-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",
-      "resolved": "http://bnpm.byted.org/url/download/url-0.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
       "requires": {
@@ -4669,7 +4669,7 @@
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "resolved": "http://bnpm.byted.org/punycode/download/punycode-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
@@ -4677,12 +4677,12 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://bnpm.byted.org/use/download/use-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
     },
     "util": {
       "version": "0.11.1",
-      "resolved": "http://bnpm.byted.org/util/download/util-0.11.1.tgz",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
       "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
       "dev": true,
       "requires": {
@@ -4691,7 +4691,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://bnpm.byted.org/inherits/download/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -4699,7 +4699,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
@@ -4715,7 +4715,7 @@
     },
     "v8flags": {
       "version": "3.1.3",
-      "resolved": "http://bnpm.byted.org/v8flags/download/v8flags-3.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
       "integrity": "sha1-/J3CNSHKIMVDP4HMTrmzAzuxBdg=",
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -4728,13 +4728,13 @@
     },
     "vm-browserify": {
       "version": "1.1.2",
-      "resolved": "http://bnpm.byted.org/vm-browserify/download/vm-browserify-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
       "dev": true
     },
     "watchpack": {
       "version": "1.6.0",
-      "resolved": "http://bnpm.byted.org/watchpack/download/watchpack-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
       "integrity": "sha1-S8EsLr6KonenHx0/FNaFx7RGzQA=",
       "dev": true,
       "requires": {
@@ -4745,7 +4745,7 @@
     },
     "webpack": {
       "version": "4.41.6",
-      "resolved": "http://bnpm.byted.org/webpack/download/webpack-4.41.6.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.6.tgz",
       "integrity": "sha1-EvL4BL9lQu8WZ1UFDUr7yPZrp+E=",
       "dev": true,
       "requires": {
@@ -4806,7 +4806,7 @@
     },
     "webpack-sources": {
       "version": "1.4.3",
-      "resolved": "http://bnpm.byted.org/webpack-sources/download/webpack-sources-1.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
       "dev": true,
       "requires": {
@@ -4816,7 +4816,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "http://bnpm.byted.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -4839,7 +4839,7 @@
     },
     "worker-farm": {
       "version": "1.7.0",
-      "resolved": "http://bnpm.byted.org/worker-farm/download/worker-farm-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
       "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
       "dev": true,
       "requires": {
@@ -4859,12 +4859,12 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://bnpm.byted.org/wrappy/download/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://bnpm.byted.org/xtend/download/xtend-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
@@ -4876,7 +4876,7 @@
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "http://bnpm.byted.org/yallist/download/yallist-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },


### PR DESCRIPTION
## Summary

- run tests, lint, builds, and package checks for pull requests and `master`
- cover the supported Node.js 22 and 24 LTS releases
- pin both the main package and SSR fixture to the public npm registry
- reject lockfiles that contain the internal `bnpm.byted.org` registry
- restrict the workflow token to read-only repository contents
- cancel superseded runs on the same branch

## Validation

- main package: `npm ci --ignore-scripts`
- SSR fixture: `npm ci --ignore-scripts`
- `npm test -- --runInBand` (38 tests)
- `npm run lint`
- `npm run build`
- `npm pack --dry-run`
- all lockfile hosts resolve to `registry.npmjs.org`