### PR TITLE
Fix scrollbar compensation for overlay scrollbars

### DIFF
--- a/src/ViewerCore.tsx
+++ b/src/ViewerCore.tsx
@@ -190,9 +190,11 @@ export default (props: ViewerProps) => {
           overflowY: document.body.style.overflowY,
           paddingRight: document.body.style.paddingRight,
         };
+        const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
         document.body.style.overflow = 'hidden';
-        if (document.body.scrollHeight > document.body.clientHeight) {
-          document.body.style.paddingRight = '15px';
+        if (document.body.scrollHeight > document.body.clientHeight && scrollbarWidth > 0) {
+          const bodyPaddingRight = parseFloat(window.getComputedStyle(document.body).paddingRight) || 0;
+          document.body.style.paddingRight = `${bodyPaddingRight + scrollbarWidth}px`;
         }
         return () => {
           document.body.style.overflow = originalBodyStyle.overflow;

--- a/src/__tests__/viewer.test.tsx
+++ b/src/__tests__/viewer.test.tsx
@@ -13,6 +13,14 @@ function $$(className) {
   return document.body.querySelectorAll(className);
 }
 
+function restoreProperty(target, property, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+  } else {
+    delete target[property];
+  }
+}
+
 interface ViewerTesterProps {
   hasContainer?: boolean;
   onChangeImages?: () => ViewerProps['images'];
@@ -585,6 +593,63 @@ describe('Viewer', () => {
     document.body.style.overflowX = '';
     document.body.style.overflowY = '';
     document.body.style.paddingRight = '';
+  });
+
+  it('preserves body padding for overlay scrollbars', () => {
+    const originalPaddingRight = document.body.style.paddingRight;
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const originalClientWidth = Object.getOwnPropertyDescriptor(document.documentElement, 'clientWidth');
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(document.body, 'scrollHeight');
+    const originalClientHeight = Object.getOwnPropertyDescriptor(document.body, 'clientHeight');
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 });
+    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: 1000 });
+    Object.defineProperty(document.body, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(document.body, 'clientHeight', { configurable: true, value: 500 });
+    let overlayViewer = null;
+
+    try {
+      document.body.style.paddingRight = '7px';
+      overlayViewer = mount(<Viewer visible={true} images={[{ src: img }]} />);
+
+      expect(document.body.style.paddingRight).toBe('7px');
+    } finally {
+      if (overlayViewer) {
+        overlayViewer.unmount();
+      }
+      document.body.style.paddingRight = originalPaddingRight;
+      restoreProperty(window, 'innerWidth', originalInnerWidth);
+      restoreProperty(document.documentElement, 'clientWidth', originalClientWidth);
+      restoreProperty(document.body, 'scrollHeight', originalScrollHeight);
+      restoreProperty(document.body, 'clientHeight', originalClientHeight);
+    }
+  });
+
+  it('adds the measured scrollbar width to existing body padding', () => {
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(window, 'innerWidth');
+    const originalClientWidth = Object.getOwnPropertyDescriptor(document.documentElement, 'clientWidth');
+    const originalScrollHeight = Object.getOwnPropertyDescriptor(document.body, 'scrollHeight');
+    const originalClientHeight = Object.getOwnPropertyDescriptor(document.body, 'clientHeight');
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1000 });
+    Object.defineProperty(document.documentElement, 'clientWidth', { configurable: true, value: 980 });
+    Object.defineProperty(document.body, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(document.body, 'clientHeight', { configurable: true, value: 500 });
+    let scrollbarViewer = null;
+
+    try {
+      document.body.style.paddingRight = '7px';
+      scrollbarViewer = mount(<Viewer visible={true} images={[{ src: img }]} />);
+
+      expect(document.body.style.paddingRight).toBe('27px');
+    } finally {
+      if (scrollbarViewer) {
+        scrollbarViewer.unmount();
+      }
+      document.body.style.paddingRight = '';
+      restoreProperty(window, 'innerWidth', originalInnerWidth);
+      restoreProperty(document.documentElement, 'clientWidth', originalClientWidth);
+      restoreProperty(document.body, 'scrollHeight', originalScrollHeight);
+      restoreProperty(document.body, 'clientHeight', originalClientHeight);
+    }
   });
 
   it('reset image', () => {


### PR DESCRIPTION
## Summary

- measure the actual scrollbar width instead of assuming 15px
- preserve existing body padding when compensating for a classic scrollbar
- avoid adding padding for overlay scrollbars such as the macOS behavior reported in #135

Related to #135. This intentionally does not auto-close the issue before maintainer follow-up.

## Reproduction and root cause

Opening the modal viewer hides body overflow. The previous code always added 15px of right padding when the page was scrollable. Overlay scrollbars occupy no layout width, so that padding shifted the page; non-15px scrollbars and pages with existing body padding were also handled incorrectly.

## Verification

- `npm run verify`
- Chromium 149 browser check against the demo at 1280x720
  - confirmed a scrollable page with a 0px overlay scrollbar
  - opened the viewer and confirmed no right padding or container shift
  - exercised zoom and closed the viewer
  - confirmed body overflow and padding were restored
- public npm registry scan passed
