### PR TITLE
Center images when the footer is hidden

### DIFF
--- a/src/ViewerCore.tsx
+++ b/src/ViewerCore.tsx
@@ -106,7 +106,7 @@ export default (props: ViewerProps) => {
     };
   }
   const containerSize = React.useRef(setContainerWidthHeight());
-  const footerHeight = constants.FOOTER_HEIGHT;
+  const footerHeight = props.noFooter ? 0 : constants.FOOTER_HEIGHT;
   function reducer(s: ViewerCoreState, action): typeof initialState {
     switch (action.type) {
       case ACTION_TYPES.setVisible:

--- a/src/__tests__/viewer.test.tsx
+++ b/src/__tests__/viewer.test.tsx
@@ -239,11 +239,15 @@ describe('Viewer', () => {
     expect($$('.react-viewer')[0].style.display).toBe('none');
   });
 
-  it('render with no footer', () => {
+  it('does not render or reserve space for the footer', () => {
     viewerHelper.new({ noFooter: true });
     viewerHelper.open();
 
     expect($$('.react-viewer-footer')).toHaveLength(0);
+    const image = $$('img.react-viewer-image')[0] as HTMLImageElement;
+    const transform = getTransformValue(image.style.transform);
+    const imageCenter = parseFloat(transform.translateY) + parseFloat(image.style.height) / 2;
+    expect(imageCenter).toBeCloseTo(window.innerHeight / 2);
   });
 
   it('render with no navbar', () => {


### PR DESCRIPTION
## Summary

- treat the effective footer height as zero when noFooter is enabled
- keep footerless images centered during initial layout, reset, and resize
- extend the noFooter test to assert that no vertical space is reserved

Related to #130. The issue is intentionally left open pending maintainer confirmation.

## Root cause

The footer DOM was hidden, but layout calculations still subtracted the fixed 84px footer height. This moved the image center 42px above the viewport center.

## Validation

- npm run verify
- registry scan: only https://registry.npmjs.org/
- Chromium 149.0.7827.55: before fix center offset -42px; after fix 0px
- Chromium resize check: center offset remains 0px; no page errors