### PR TITLE
Support modern bundler imports and prepare v3.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ import React, { FC } from 'react'
 import dynamic from 'next/dynamic'
 
 const ReactViewer = dynamic(
-  () => import('react-viewer'),
+  () => import('react-viewer').then((mod) => mod.default),
   { ssr: false }
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-viewer",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-viewer",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "react image viewer",
   "main": "dist/index",
   "scripts": {
@@ -10,9 +10,10 @@
     "build": "webpack --config webpack.config.prop.js && npm run build:types",
     "build:types": "node -e \"require('fs-extra').removeSync('lib')\" && tsc -p tsconfig.build.json",
     "build:ssr": "npm --prefix ssr-test ci --ignore-scripts && npm --prefix ssr-test run build",
+    "check:package-export": "node scripts/check-package-export.js",
     "build:analyze": "ANALYZE=true webpack --config webpack.config.prop.js",
     "doc": "webpack --config webpack.config.doc.js",
-    "verify": "npm test -- --runInBand && npm run lint && npm run build && npm run doc && npm run build:ssr && npm pack --dry-run",
+    "verify": "npm test -- --runInBand && npm run lint && npm run build && npm run check:package-export && npm run doc && npm run build:ssr && npm pack --dry-run",
     "pub": "npm publish",
     "prepublishOnly": "npm run build",
     "predeploy": "npm run doc",
@@ -68,6 +69,7 @@
     "jest-environment-jsdom": "^23.4.0",
     "jest-environment-jsdom-global": "^1.1.0",
     "jest-static-stubs": "0.0.1",
+    "jsdom": "^11.12.0",
     "less": "^3.10.3",
     "less-loader": "^5.0.0",
     "merge2": "^1.3.0",

--- a/scripts/check-package-export.js
+++ b/scripts/check-package-export.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM('<!doctype html><html><head></head><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+
+const Viewer = require('../dist');
+assert.strictEqual(
+  typeof Viewer,
+  'function',
+  'The CommonJS package entry must export the Viewer component directly'
+);
+
+console.log('Package default export is a component.');
+dom.window.close();
+process.exit(0);

--- a/webpack.config.prop.js
+++ b/webpack.config.prop.js
@@ -10,6 +10,7 @@ if (fs.existsSync(distPath)) {
 
 config.output.merge({
   library: 'react-viewer',
+  libraryExport: 'default',
   libraryTarget: 'umd',
   globalObject: 'this'
 });


### PR DESCRIPTION
## Summary

- export the Viewer component directly from the UMD package entry so documented default imports work in modern bundlers
- update the Next.js client-only example to unwrap the CommonJS default explicitly
- add a release verification check for the built package export
- bump the patch version to 3.2.4

Related to #198. This does not add server-side Viewer rendering; the documented client-only Next.js integration remains required.

## Reproduction

The 3.2.3 tarball built successfully with current tools, but default imports resolved to a module object at runtime. React 19/Vite 8 reported an invalid element type, and Next.js 16 reported React error 306.

## Validation

- npm run verify
- public npm registry scan
- React 19.2.8 + Vite 8.2.2 production build
- Next.js 16.3.1 + React 19.2.8 production build with a statically prerendered App Router page
- Chromium 149.0.7827.55: both fixtures hydrated, opened Viewer, loaded an image, and closed with Escape without page errors
- npm pack dry run for react-viewer@3.2.4